### PR TITLE
In github actions makefile, make submodule paths relative to workspace.

### DIFF
--- a/MAKE/Makefile.github_actions
+++ b/MAKE/Makefile.github_actions
@@ -76,9 +76,9 @@ LIB_SILO = -lsiloh5
 INC_PAPI =
 LIB_PAPI = -lpapi
 
-INC_DCCRG = -I./submodules/dccrg
-INC_EIGEN = -I./submodules/eigen
-INC_FSGRID = -I./submodules/fsgrid
+INC_DCCRG = -I${GITHUB_WORKSPACE}/submodules/dccrg
+INC_EIGEN = -I${GITHUB_WORKSPACE}/submodules/eigen
+INC_FSGRID = -I${GITHUB_WORKSPACE}/submodules/fsgrid
 
 LIB_PROFILE = -I $(LIBRARY_PREFIX)/include ${GITHUB_WORKSPACE}/libraries/lib/libphiprof.a
 INC_PROFILE =


### PR DESCRIPTION
Otherwise, ionosphere miniApp compilation would fail.